### PR TITLE
Remove useless p tag

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,7 +33,7 @@ about: 'about.html'
 
         </header>
         <section class="post-excerpt">
-            <p>{{post.excerpt}}</p>
+            {{post.excerpt}}
         </section>
     </article>
 


### PR DESCRIPTION
This fix, along with the previous pull request, should remove most (or all) HTML5 syntax errors.

By wrapping {{post.excerpt}} in a p tag, the end result in <p><p>post excerpt</p></p>. W3C's validator complains about the superposition of those tags.
