### PR TITLE
Fix for categories not displayed

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -62,15 +62,15 @@ archive: false
 
             <section class="share">
                 <h4>Share this post</h4>
-                <a class="icon-twitter" href="http://twitter.com/share?text={{page.title}}&amp;url={{ page.url }}"
+                <a class="icon-twitter" href="http://twitter.com/share?text={{page.title}}&amp;url={{site.url}}{{ page.url }}"
                     onclick="window.open(this.href, 'twitter-share', 'width=550,height=235');return false;">
                     <span class="hidden">Twitter</span>
                 </a>
-                <a class="icon-facebook" href="https://www.facebook.com/sharer/sharer.php?u={{page.url}}"
+                <a class="icon-facebook" href="https://www.facebook.com/sharer/sharer.php?u={{site.url}}{{page.url}}"
                     onclick="window.open(this.href, 'facebook-share','width=580,height=296');return false;">
                     <span class="hidden">Facebook</span>
                 </a>
-                <a class="icon-google-plus" href="https://plus.google.com/share?url={{page.url}}"
+                <a class="icon-google-plus" href="https://plus.google.com/share?url={{site.url}}{{page.url}}"
                    onclick="window.open(this.href, 'google-plus-share', 'width=490,height=530');return false;">
                     <span class="hidden">Google+</span>
                 </a>


### PR DESCRIPTION
Currently, even if categories are mentioned in markdown post, it is not displayed after site generation. This is because, the if condition should be on page.categories & not on post.categories
