### PR TITLE
Update configuration to work with latest Jekyll

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,8 @@
+source 'https://rubygems.org'
+
+ruby "2.2.3"
+
+gem "jekyll"
+gem "jekyll-paginate"
+gem "pygments.rb"
+gem "kramdown"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,48 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    colorator (0.1)
+    ffi (1.9.10)
+    jekyll (3.0.1)
+      colorator (~> 0.1)
+      jekyll-sass-converter (~> 1.0)
+      jekyll-watch (~> 1.1)
+      kramdown (~> 1.3)
+      liquid (~> 3.0)
+      mercenary (~> 0.3.3)
+      rouge (~> 1.7)
+      safe_yaml (~> 1.0)
+    jekyll-paginate (1.1.0)
+    jekyll-sass-converter (1.4.0)
+      sass (~> 3.4)
+    jekyll-watch (1.3.0)
+      listen (~> 3.0)
+    kramdown (1.9.0)
+    liquid (3.0.6)
+    listen (3.0.5)
+      rb-fsevent (>= 0.9.3)
+      rb-inotify (>= 0.9)
+    mercenary (0.3.5)
+    posix-spawn (0.3.11)
+    pygments.rb (0.6.3)
+      posix-spawn (~> 0.3.6)
+      yajl-ruby (~> 1.2.0)
+    rb-fsevent (0.9.7)
+    rb-inotify (0.9.5)
+      ffi (>= 0.5.0)
+    rouge (1.10.1)
+    safe_yaml (1.0.4)
+    sass (3.4.20)
+    yajl-ruby (1.2.1)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  jekyll
+  jekyll-paginate
+  kramdown
+  pygments.rb
+
+BUNDLED WITH
+   1.11.2

--- a/_config.yml
+++ b/_config.yml
@@ -3,6 +3,9 @@ description: Blogging about stuffs
 meta_description: "Your New Jekyll Site, Blogging about stuffs"
 
 markdown: kramdown
+exclude: [vendor]
+gems: [jekyll-paginate]
+
 highlighter: pygments
 logo: false
 paginate: 15

--- a/_plugins/rssgenerator.rb
+++ b/_plugins/rssgenerator.rb
@@ -1,0 +1,121 @@
+# Jekyll plugin for generating an rss 2.0 feed for posts
+#
+# Usage: place this file in the _plugins directory and set the required configuration
+#        attributes in the _config.yml file
+#
+# Uses the following attributes in _config.yml:
+#   name           - the name of the site
+#   url            - the url of the site
+#   description    - (optional) a description for the feed (if not specified will be generated from name)
+#   author         - (optional) the author of the site (if not specified will be left blank)
+#   copyright      - (optional) the copyright of the feed (if not specified will be left blank)
+#   rss_path       - (optional) the path to the feed (if not specified "/" will be used)
+#   rss_name       - (optional) the name of the rss file (if not specified "rss.xml" will be used)
+#   rss_post_limit - (optional) the number of posts in the feed
+#
+# Author: Assaf Gelber <assaf.gelber@gmail.com>
+# Site: http://agelber.com
+# Source: http://github.com/agelber/jekyll-rss
+#
+# Distributed under the MIT license
+# Copyright Assaf Gelber 2014
+
+module Jekyll
+  class RssFeed < Page; end
+
+  class RssGenerator < Generator
+    priority :low
+    safe true
+
+    # Generates an rss 2.0 feed
+    #
+    # site - the site
+    #
+    # Returns nothing
+    def generate(site)
+      require 'rss'
+      require 'cgi/util'
+
+      # Create the rss with the help of the RSS module
+      rss = RSS::Maker.make("2.0") do |maker|
+        maker.channel.title = site.config['name']
+        maker.channel.link = site.config['url']
+        maker.channel.description = site.config['description'] || "RSS feed for #{site.config['name']}"
+        maker.channel.author = site.config["author"]
+        maker.channel.updated = site.posts.docs.map { |p| p.date  }.max
+        maker.channel.copyright = site.config['copyright']
+
+        post_limit = site.config['rss_post_limit'].nil? ? site.posts.docs.count : site.config['rss_post_limit'] - 1
+
+        site.posts.docs.reverse[0..post_limit].each do |doc|
+          doc.read
+          maker.items.new_item do |item|
+            link = "#{site.config['url']}#{doc.url}"
+            item.guid.content = link
+            item.title = doc.data['title']
+            item.link = link
+            item.description = "<![CDATA[" + doc.data['excerpt'].to_s.gsub(%r{</?[^>]+?>}, '') + "]]>"
+
+            # the whole doc content, wrapped in CDATA tags
+            item.content_encoded = "<![CDATA[" + doc.content + "]]>"
+
+            item.updated = doc.date
+          end
+        end
+      end
+
+      # File creation and writing
+      rss_path = ensure_slashes(site.config['rss_path'] || "/")
+      rss_name = site.config['rss_name'] || "rss.xml"
+      full_path = File.join(site.dest, rss_path)
+      ensure_dir(full_path)
+
+      # We only have HTML in our content_encoded field which is surrounded by CDATA.
+      # So it should be safe to unescape the HTML.
+      feed = CGI::unescapeHTML(rss.to_s)
+
+      File.open("#{full_path}#{rss_name}", "w") { |f| f.write(feed) }
+
+      # Add the feed page to the site pages
+      site.pages << Jekyll::RssFeed.new(site, site.dest, rss_path, rss_name)
+    end
+
+    private
+
+    # Ensures the given path has leading and trailing slashes
+    #
+    # path - the string path
+    #
+    # Return the path with leading and trailing slashes
+    def ensure_slashes(path)
+      ensure_leading_slash(ensure_trailing_slash(path))
+    end
+
+    # Ensures the given path has a leading slash
+    #
+    # path - the string path
+    #
+    # Returns the path with a leading slash
+    def ensure_leading_slash(path)
+      path[0] == "/" ? path : "/#{path}"
+    end
+
+    # Ensures the given path has a trailing slash
+    #
+    # path - the string path
+    #
+    # Returns the path with a trailing slash
+    def ensure_trailing_slash(path)
+      path[-1] == "/" ? path : "#{path}/"
+    end
+
+    # Ensures the given directory exists
+    #
+    # path - the string path of the directory
+    #
+    # Returns nothing
+    def ensure_dir(path)
+      FileUtils.mkdir_p(path)
+    end
+  end
+end

--- a/_posts/2013-11-10-welcome-to-jekyll.markdown
+++ b/_posts/2013-11-10-welcome-to-jekyll.markdown
@@ -3,6 +3,7 @@ layout: post
 title:  "Welcome to Jekyll!"
 date:   2013-11-10 10:18:00
 categories: Thriller Comedy Horror
+excerpt: Let me introduce it to you
 ---
 
 You'll find this post in your `_posts` directory - edit this post and re-build (or run with the `-w` switch) to see your changes!


### PR DESCRIPTION
Hi,
When I forked the theme I encountered a few issues with latest Jekyll version so I've created pull request with all necessary fixes.

I also think it's a good practice to include `Gemfile` with all necessary gems (especially Readme doesn't say anything about necessary additional libraries and its versions).

Other things I did it here:
* Updated rss generator plugin.
* Added missing excerpt property in the welcome post.
* Updated config to include `jekyll-paginate` and skip posts from `jekyll` gem directory.