### PR TITLE
fix: add paginate gem in config

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -9,6 +9,7 @@ paginate: 15
 baseurl: /
 domain_name: 'http://yourblog-domain.com'
 google_analytics: 'UA-XXXXXXXX-X'
+gems: [jekyll-paginate]
 
 # Details for the RSS feed generator
 url:            'blog url'


### PR DESCRIPTION
- After i clone the code form you repo, run `jekyll serve`, and it said that i should have `gems: [jekyll-paginate]` in config.