### PR TITLE
Fixed `gems` to `plugins` in _config.yaml and added a mention to install jekyll-paginate in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Feel free to fork, change, modify and re-use it.
     git clone https://github.com/rosario/kasper.git
     cd kasper
     gem install jekyll
+    gem install jekyll-paginate
     gem install pygments.rb
 
 ## How to use it

--- a/_config.yml
+++ b/_config.yml
@@ -9,7 +9,7 @@ paginate: 15
 baseurl: /
 domain_name: 'http://yourblog-domain.com'
 google_analytics: 'UA-XXXXXXXX-X'
-gems: [jekyll-paginate]
+plugins: [jekyll-paginate]
 
 # Details for the RSS feed generator
 url:            'blog url'


### PR DESCRIPTION
Tried to use it with the latest version of Jekyll and got a couple of errors. Had to change `gems` to `plugins` and it could not find `jekyll-paginate` so I added the command to install it to the README as well.