### PR TITLE
README update and renaming deprecated option in `_config.yml`

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Feel free to fork, change, modify and re-use it.
     cd kasper
     gem install jekyll
     gem install pygments.rb
+    gem install jekyll-paginate
 
 ## How to use it
 

--- a/_config.yml
+++ b/_config.yml
@@ -9,7 +9,7 @@ paginate: 15
 baseurl: /
 domain_name: 'http://yourblog-domain.com'
 google_analytics: 'UA-XXXXXXXX-X'
-gems: [jekyll-paginate]
+plugins: [jekyll-paginate]
 
 # Details for the RSS feed generator
 url:            'blog url'


### PR DESCRIPTION
Following the README instructions to get started throws the following warnings and errors:
```
Deprecation: The 'gems' configuration option has been renamed to 'plugins'. 
Please update your config file accordingly.
Dependency Error: Yikes! It looks like you don't have jekyll-paginate or 
one of its dependencies installed. 
In order to use Jekyll as currently configured, you'll need to install this gem. 
The full error message from Ruby is: 'cannot load such file -- jekyll-paginate' 
If you run into trouble, you can find helpful resources at https://jekyllrb.com/help/!
```
* `README.md` updated with added instruction
* `_config.yml` updated with new option