### PR TITLE
fix pagination.html error

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -6,6 +6,7 @@ markdown: kramdown
 highlighter: rouge
 logo: false
 paginate: 15
+paginate_path: "/page:num"
 baseurl: /kasper
 domain_name: "http://yourblog-domain.com"
 google_analytics: "UA-XXXXXXXX-X"

--- a/_includes/pagination.html
+++ b/_includes/pagination.html
@@ -3,11 +3,11 @@
         {% if paginator.previous_page == 1 %}
             <a class="newer-posts" href="/" title="Previous Page">&laquo; Newer Posts</a>
         {% else %}
-            <a class="newer-posts" href="{{'/page'paginator.previous_page | relative_url}}/" title="Previous Page">&laquo; Newer Posts</a>
+            <a class="newer-posts" href="/page{{ paginator.previous_page }}/" title="Previous Page">&laquo; Newer Posts</a>
       {% endif %}
     {% endif %}
     <span class="page-number"> Page {{paginator.page}} of {{paginator.total_pages}} </span>
     {% if paginator.next_page %} 
-        <a class="older-posts" href="{{'/page'paginator.next_page | relative_url }}/" title="Next Page">Older Posts &raquo;</a>
+        <a class="older-posts" href="/page{{ paginator.next_page }}/" title="Next Page">Older Posts &raquo;</a>
     {% endif %} 
 </nav>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/24474531/120110083-c9d36500-c19e-11eb-928e-33b5cf61f2a4.png)

![image](https://user-images.githubusercontent.com/24474531/120110108-da83db00-c19e-11eb-888a-ce6f23cbac43.png)

When I am using pagination, there is a 404 Not Found occur.

According to the [Pagination-JekyllCN Docs ](https://jekyllcn.com/docs/pagination/), 

```ruby
<div class="pagination">
  {% if paginator.previous_page %}
    <a href="/page{{ paginator.previous_page }}" class="previous">Previous</a>
  {% else %}
    <span class="previous">Previous</span>
  {% endif %}
  <span class="page_number ">Page: {{ paginator.page }} of {{ paginator.total_pages }}</span>
  {% if paginator.next_page %}
    <a href="/page{{ paginator.next_page }}" class="next">Next</a>
  {% else %}
    <span class="next ">Next</span>
  {% endif %}
</div>
```

`<a href="/page{{ paginator.next_page }}" class="next">Next</a>` is the correct setting.

After changing the `pagination.html` and `_config.yml`, the Next Page can work properly.

